### PR TITLE
Update cloudflare a record on terraform deploy

### DIFF
--- a/terraform-docker-app/.terraform.lock.hcl
+++ b/terraform-docker-app/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "4.52.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:NHZ5RJIzQDLhie/ykl3uI6UPfNQR9Lu5Ti7JPR6X904=",
+    "zh:2fb95e1d3229b9b6c704e1a413c7481c60f139780d9641f657b6eb9b633b90f2",
+    "zh:379c7680983383862236e9e6e720c3114195c40526172188e88d0ffcf50dfe2e",
+    "zh:55533beb6cfc02d22ffda8cba8027bc2c841bb172cd637ed0d28323d41395f8f",
+    "zh:5abd70760e4eb1f37a1c307cbd2989ea7c9ba0afb93818c67c1d363a31f75703",
+    "zh:699f1c8cd66129176fe659ebf0e6337632a8967a28d2630b6ae5948665c0c2ae",
+    "zh:69c15acd73c451e89de6477059cda2f3ec200b48ae4b9ff3646c4d389fd3205e",
+    "zh:6e02b687de21b844f8266dff99e93e7c61fc8eb688f4bbb23803caceb251839e",
+    "zh:7a51d17b87ed87b7bebf2ad9fc7c3a74f16a1b44eee92c779c08eb89258c0496",
+    "zh:88ad84436837b0f55302f22748505972634e87400d6902260fd6b7ba1610f937",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8d46c3d9f4f7ad20ac6ef01daa63f4e30a2d16dcb1bb5c7c7ee3dc6be38e9ca1",
+    "zh:913d64e72a4929dae1d4793e2004f4f9a58b138ea337d9d94fa35cafbf06550a",
+    "zh:c8d93cf86e2e49f6cec665cfe78b82c144cce15a8b2e30f343385fadd1251849",
+    "zh:cc4f69397d9bc34a528a5609a024c3a48f54f21616c0008792dd417297add955",
+    "zh:df99cdb8b064aad35ffea77e645cf6541d0b1b2ebc51b6d26c42031de60ab69e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.117.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:3c9iOEtBMnHrpJLlhbQ0sCZPWhE/2dvEPcL8KkXAh7w=",
+    "zh:0c513676836e3c50d004ece7d2624a8aff6faac14b833b96feeac2e4bc2c1c12",
+    "zh:50ea01ada95bae2f187db9e926e463f45d860767a85ebc59160414e00e76c35d",
+    "zh:52c2a9edacc06b3f72153f5ef6daca0761c6292158815961fe37f60bc576a3d7",
+    "zh:618eed2a06b19b1a025b45b05891846d570a6a1cca4d23f4942f5a99e1f747ae",
+    "zh:61cde5d3165d7e5ec311d5d89486819cd605c1b2d54611b5c97bd4e97dba2762",
+    "zh:6a873358d5031fc222f5e05f029d1237f3dce8345c767665f393283dfa2627f6",
+    "zh:afdd80064b2a04da311856feb4ed45f77ff4df6c356e8c2b10afb51fe7e61c70",
+    "zh:b09113df7e0e8c8959539bd22bae6c39faeb269ba3c4cd948e742f5cf58c35fb",
+    "zh:d340db7973109761cfc27d52aa02560363337c908b2c99b3628adc5a70a99d5b",
+    "zh:d5a577226ebc8c65e8f19384878a86acc4b51ede4b4a82d37c3b331b0efcd4a7",
+    "zh:e2962b147f9e71732df8dbc74940c10d20906f3c003cbfaa1eb9fabbf601a9f0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform-docker-app/cloudflare.tf
+++ b/terraform-docker-app/cloudflare.tf
@@ -1,0 +1,19 @@
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+# Lookup the Cloudflare zone by name (e.g., example.com)
+data "cloudflare_zone" "selected" {
+  name = var.cloudflare_zone_name
+}
+
+# Create or update an A record pointing to the VM's public IP
+resource "cloudflare_record" "vm_a" {
+  zone_id         = data.cloudflare_zone.selected.id
+  name            = var.cloudflare_record_name
+  type            = "A"
+  value           = azurerm_public_ip.public_ip.ip_address
+  ttl             = var.cloudflare_proxied ? 1 : var.cloudflare_ttl
+  proxied         = var.cloudflare_proxied
+  allow_overwrite = true
+}

--- a/terraform-docker-app/main.tf
+++ b/terraform-docker-app/main.tf
@@ -9,6 +9,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
   }
 
   backend "azurerm" {}

--- a/terraform-docker-app/variables.tf
+++ b/terraform-docker-app/variables.tf
@@ -31,3 +31,32 @@ variable "prefix" {
 #   type        = string
 #   sensitive   = true # This prevents the value from being printed in Terraform logs.
 # }
+
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with DNS Edit permissions for the target zone"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_zone_name" {
+  description = "Cloudflare zone name (apex/root domain), e.g., example.com"
+  type        = string
+}
+
+variable "cloudflare_record_name" {
+  description = "DNS record name relative to the zone (e.g., 'app' or '@' for root)"
+  type        = string
+  default     = "@"
+}
+
+variable "cloudflare_proxied" {
+  description = "Whether Cloudflare proxy (orange cloud) should be enabled for the record"
+  type        = bool
+  default     = true
+}
+
+variable "cloudflare_ttl" {
+  description = "TTL for the DNS record (ignored when proxied is true). Use 1 for 'auto'."
+  type        = number
+  default     = 300
+}


### PR DESCRIPTION
Automate Cloudflare A record updates to map a URL to the VM's public IP during Terraform deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb1180a5-4be1-479e-9855-8c57de0c5f8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cb1180a5-4be1-479e-9855-8c57de0c5f8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

