### PR TITLE
Add backend and frontend VMs

### DIFF
--- a/terraform-docker-app/outputs.tf
+++ b/terraform-docker-app/outputs.tf
@@ -4,11 +4,16 @@ output "resource_group_name" {
   value       = azurerm_resource_group.rg.name
 }
 
-# Output the public IP address of the Docker VM.
-# This is crucial for accessing your VM (e.g., via SSH or a web server running on it).
-output "vm_public_ip" {
-  description = "The public IP address of the Docker VM."
-  value       = azurerm_public_ip.public_ip.ip_address
+# Output the public IP address of the backend VM.
+output "backend_vm_public_ip" {
+  description = "The public IP address of the backend VM."
+  value       = azurerm_public_ip.backend_public_ip.ip_address
+}
+
+# Output the public IP address of the frontend VM.
+output "frontend_vm_public_ip" {
+  description = "The public IP address of the frontend VM."
+  value       = azurerm_public_ip.frontend_public_ip.ip_address
 }
 
 # Output the Azure region where the VM is deployed.


### PR DESCRIPTION
## Summary
- define separate public IPs, NICs, and VMs for backend and frontend
- output public IP addresses for both instances

## Testing
- `terraform fmt`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: required provider hashicorp/azurerm not available)*

------
https://chatgpt.com/codex/tasks/task_e_6896914fcba883328023d07aa1b6b2d1