### PR TITLE
Enable HTTPS access for VMs and set up SSL certificates

### DIFF
--- a/terraform-docker-app/docker-startup.sh
+++ b/terraform-docker-app/docker-startup.sh
@@ -1,12 +1,32 @@
 #!/bin/bash
 apt-get update
-apt-get install -y docker.io git
+apt-get install -y docker.io git openssl
 usermod -aG docker azureuser
 
-# Pull your frontend and backend images from Docker Hub (replace with your actual image names)
-docker pull yourdockerhubuser/frontend-image:latest
-docker pull yourdockerhubuser/backend-image:latest
+# Generate a self-signed certificate for HTTPS
+mkdir -p /etc/ssl/docker
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout /etc/ssl/docker/selfsigned.key \
+  -out /etc/ssl/docker/selfsigned.crt \
+  -subj "/CN=localhost"
 
-# Run frontend (on port 80) and backend (on port 5000 or any other)
-docker run -d --name frontend -p 80:80 yourdockerhubuser/frontend-image:latest
-docker run -d --name backend -p 5000:5000 yourdockerhubuser/backend-image:latest
+HOSTNAME=$(hostname)
+
+if [[ "$HOSTNAME" == *"frontend"* ]]; then
+  # Pull and run the frontend container exposing HTTPS
+  docker pull yourdockerhubuser/frontend-image:latest
+  docker run -d --name frontend -p 80:80 -p 443:80 \
+    -v /etc/ssl/docker:/etc/ssl/docker \
+    -e SSL_CERT=/etc/ssl/docker/selfsigned.crt \
+    -e SSL_KEY=/etc/ssl/docker/selfsigned.key \
+    yourdockerhubuser/frontend-image:latest
+elif [[ "$HOSTNAME" == *"backend"* ]]; then
+  # Pull and run the backend container exposing HTTPS
+  docker pull yourdockerhubuser/backend-image:latest
+  docker run -d --name backend -p 5000:5000 -p 443:5000 \
+    -v /etc/ssl/docker:/etc/ssl/docker \
+    -e SSL_CERT=/etc/ssl/docker/selfsigned.crt \
+    -e SSL_KEY=/etc/ssl/docker/selfsigned.key \
+    yourdockerhubuser/backend-image:latest
+fi
+

--- a/terraform-docker-app/main.tf
+++ b/terraform-docker-app/main.tf
@@ -49,6 +49,18 @@ resource "azurerm_network_security_group" "security_group" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+
+  security_rule {
+    name                       = "AllowHTTPS"
+    priority                   = 120
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
 }
 
 # ------------------ Virtual Network ------------------


### PR DESCRIPTION
## Summary
- Open port 443 on the VM network security group to allow HTTPS traffic
- Generate self-signed certificates and run frontend or backend containers with HTTPS based on VM role

## Testing
- `terraform fmt -check`
- `terraform init -backend=false` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: Missing required provider hashicorp/azurerm)*

------
https://chatgpt.com/codex/tasks/task_e_689695dd591883329a8ba8c39bd2e3d2