### PR TITLE
Use Docker Compose for backend deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Cloud-Devops
 
-A repository to depoly the frontend and backend of the tiffinbox application
+A repository to deploy the frontend and backend of the tiffinbox application.
+
+## Backend
+
+Run the backend locally with Docker Compose:
+
+```bash
+git clone https://github.com/Appster-Capstone-Project/Capstone-Project-Backend.git
+cd Capstone-Project-Backend
+docker compose up -d
+```
+
+The service exposes port `8000`.

--- a/terraform-docker-app/docker-startup.sh
+++ b/terraform-docker-app/docker-startup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 apt-get update
-apt-get install -y docker.io git openssl
+apt-get install -y docker.io docker-compose-plugin git openssl
 usermod -aG docker azureuser
 
 # Generate a self-signed certificate for HTTPS
@@ -21,12 +21,9 @@ if [[ "$HOSTNAME" == *"frontend"* ]]; then
     -e SSL_KEY=/etc/ssl/docker/selfsigned.key \
     yourdockerhubuser/frontend-image:latest
 elif [[ "$HOSTNAME" == *"backend"* ]]; then
-  # Pull and run the backend container exposing HTTPS
-  docker pull yourdockerhubuser/backend-image:latest
-  docker run -d --name backend -p 5000:5000 -p 443:5000 \
-    -v /etc/ssl/docker:/etc/ssl/docker \
-    -e SSL_CERT=/etc/ssl/docker/selfsigned.crt \
-    -e SSL_KEY=/etc/ssl/docker/selfsigned.key \
-    yourdockerhubuser/backend-image:latest
+  # Clone and run the backend application using Docker Compose
+  git clone https://github.com/Appster-Capstone-Project/Capstone-Project-Backend.git /opt/backend
+  cd /opt/backend || exit
+  docker compose up -d
 fi
 


### PR DESCRIPTION
## Summary
- install docker-compose plugin and clone backend repository at startup
- document running backend with `docker compose up`

## Testing
- `bash -n terraform-docker-app/docker-startup.sh`
- `shellcheck terraform-docker-app/docker-startup.sh`
- `apt-get install -y terraform` *(failed: Unable to locate package terraform)*

------
https://chatgpt.com/codex/tasks/task_e_68969805896c8332a60b879538430342